### PR TITLE
feat: add schema.emptyData() convenience wrapper

### DIFF
--- a/.changeset/schema-empty-data.md
+++ b/.changeset/schema-empty-data.md
@@ -1,0 +1,5 @@
+---
+'miragejs-orm': minor
+---
+
+Add `schema.emptyData()` convenience method that wraps `schema.db.emptyData()`, so all collection data can be cleared directly from the schema instance.

--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ await testSchema.loadSeeds({ onlyDefault: true });
 | `loadSeeds(collectionName)`             | Load all seeds for one collection.                                           |
 | `loadSeeds({ onlyDefault: true })`      | Load only the `default` scenario across collections.                         |
 | `loadFixtures(collectionName?)`         | Load fixtures for all collections, or one by name.                           |
+| `emptyData()`                           | Clear all records in all collections (wraps `db.emptyData()`).               |
 | `db`                                    | The underlying `DB` instance (see [Direct Database Access](#direct-database-access)). |
 
 </details>
@@ -1310,7 +1311,7 @@ import { testSchema } from '@test/schema';
 
 describe('User Management', () => {
   beforeEach(() => {
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   it('should create a user with posts', () => {
@@ -1358,7 +1359,7 @@ import { testSchema } from './schema';
 export const test = baseTest.extend<{ schema: typeof testSchema }>({
   schema: async ({}, use) => {
     await use(testSchema);
-    testSchema.db.emptyData(); // Teardown: clean after each test
+    testSchema.emptyData(); // Teardown: clean after each test
   },
 });
 ```

--- a/lib/src/factory/__tests__/Factory.test.ts
+++ b/lib/src/factory/__tests__/Factory.test.ts
@@ -50,7 +50,7 @@ type TestSchema = {
 describe('Factory', () => {
   beforeEach(() => {
     // Clear database before each test
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Constructor', () => {

--- a/lib/src/factory/__tests__/FactoryBuilder.test.ts
+++ b/lib/src/factory/__tests__/FactoryBuilder.test.ts
@@ -46,7 +46,7 @@ type TestSchema = {
 describe('FactoryBuilder', () => {
   beforeEach(() => {
     // Clear database before each test
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Constructor', () => {

--- a/lib/src/model/__tests__/Model.test.ts
+++ b/lib/src/model/__tests__/Model.test.ts
@@ -91,7 +91,7 @@ const testSchema = schema()
 describe('Model', () => {
   beforeEach(() => {
     // Clear test database
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Constructor', () => {

--- a/lib/src/model/__tests__/ModelCollection.test.ts
+++ b/lib/src/model/__tests__/ModelCollection.test.ts
@@ -64,7 +64,7 @@ describe('ModelCollection', () => {
   });
 
   afterEach(() => {
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Constructor', () => {

--- a/lib/src/schema/BaseCollection.ts
+++ b/lib/src/schema/BaseCollection.ts
@@ -455,7 +455,7 @@ export abstract class BaseCollection<
 
   /**
    * Resets the seed tracking, allowing seeds to be loaded again.
-   * Called automatically when the collection data is cleared via db.emptyData().
+   * Called automatically when the collection data is cleared via schema.emptyData().
    */
   resetSeedTracking(): void {
     this._loadedSeeds.clear();

--- a/lib/src/schema/Collection.ts
+++ b/lib/src/schema/Collection.ts
@@ -448,7 +448,7 @@ export default class Collection<
       throw new MirageError(
         `Cannot load fixtures for '${this.collectionName}': ID conflicts detected. ` +
           `The following fixture IDs already exist in the database: ${conflicts.join(', ')}. ` +
-          `Clear the database with db.emptyData() before loading fixtures, or use different IDs.`,
+          `Clear the database with schema.emptyData() before loading fixtures, or use different IDs.`,
       );
     }
 

--- a/lib/src/schema/Schema.ts
+++ b/lib/src/schema/Schema.ts
@@ -204,11 +204,23 @@ export default class Schema<
   }
 
   /**
-   * Resets seed tracking for all collections, allowing seeds to be reloaded.
-   * Call this after db.emptyData() if you need to reload seeds.
+   * Empties the data from all collections in the database.
+   * Convenience wrapper around `schema.db.emptyData()`.
    * @example
    * ```typescript
-   * schema.db.emptyData();
+   * schema.emptyData();
+   * ```
+   */
+  emptyData(): void {
+    this.db.emptyData();
+  }
+
+  /**
+   * Resets seed tracking for all collections, allowing seeds to be reloaded.
+   * Call this after emptyData() if you need to reload seeds.
+   * @example
+   * ```typescript
+   * schema.emptyData();
    * schema.resetSeedTracking();
    * await schema.loadSeeds(); // Seeds can now be loaded again
    * ```

--- a/lib/src/schema/__tests__/BaseCollection.test.ts
+++ b/lib/src/schema/__tests__/BaseCollection.test.ts
@@ -186,7 +186,7 @@ describe('BaseCollection', () => {
       expect(post?.attrs.authorId).toBe('1');
 
       // Cleanup
-      testSchema.db.emptyData();
+      testSchema.emptyData();
     });
   });
 

--- a/lib/src/schema/__tests__/Schema.fixtures.test.ts
+++ b/lib/src/schema/__tests__/Schema.fixtures.test.ts
@@ -78,7 +78,7 @@ describe('Schema with Fixtures', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
       });
 
       it('should load fixtures when called', async () => {
@@ -176,7 +176,7 @@ describe('Schema with Fixtures', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
       });
 
       it('should do nothing when loadFixtures is called', async () => {
@@ -195,7 +195,7 @@ describe('Schema with Fixtures', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
       });
 
       it('should do nothing when loadFixtures is called', async () => {
@@ -256,7 +256,7 @@ describe('Schema with Fixtures', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
       });
 
       it('should load all fixtures for all collections', async () => {
@@ -555,7 +555,7 @@ describe('Schema with Fixtures', () => {
       );
 
       await expect(testSchema.users.loadFixtures()).rejects.toThrow(
-        'Clear the database with db.emptyData()',
+        'Clear the database with schema.emptyData()',
       );
     });
 

--- a/lib/src/schema/__tests__/Schema.relationships.test.ts
+++ b/lib/src/schema/__tests__/Schema.relationships.test.ts
@@ -54,7 +54,7 @@ const testSchema = schema()
 
 describe('Schema with Relationships', () => {
   beforeEach(() => {
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Relationships initialization', () => {

--- a/lib/src/schema/__tests__/Schema.seeds.test.ts
+++ b/lib/src/schema/__tests__/Schema.seeds.test.ts
@@ -32,7 +32,7 @@ describe('Schema with Seeds', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
       });
 
@@ -86,7 +86,7 @@ describe('Schema with Seeds', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
       });
 
@@ -140,7 +140,7 @@ describe('Schema with Seeds', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
       });
 
@@ -179,7 +179,7 @@ describe('Schema with Seeds', () => {
         .build();
 
       beforeEach(() => {
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
       });
 
@@ -215,7 +215,7 @@ describe('Schema with Seeds', () => {
       .build();
 
     beforeEach(() => {
-      testSchema.db.emptyData();
+      testSchema.emptyData();
       testSchema.resetSeedTracking();
     });
 
@@ -466,7 +466,7 @@ describe('Schema with Seeds', () => {
         expect(testSchema.users.all().length).toBe(1);
 
         // Empty the collection
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
         expect(testSchema.users.all().length).toBe(0);
 
@@ -603,7 +603,7 @@ describe('Schema with Seeds', () => {
         expect(testSchema.users.all().length).toBe(1);
 
         // Empty collection
-        testSchema.db.emptyData();
+        testSchema.emptyData();
         testSchema.resetSeedTracking();
 
         // Load seeds again - should work because collection is empty

--- a/lib/src/schema/__tests__/Schema.test.ts
+++ b/lib/src/schema/__tests__/Schema.test.ts
@@ -31,7 +31,7 @@ const testSchema = schema()
 
 describe('Schema', () => {
   beforeEach(() => {
-    testSchema.db.emptyData();
+    testSchema.emptyData();
   });
 
   describe('Constructor', () => {
@@ -155,6 +155,18 @@ describe('Schema', () => {
       testSchema.users.delete(user.id);
       const retrieved = testSchema.users.find(user.id);
       expect(retrieved).toBeNull();
+    });
+
+    it('empties data from all collections via emptyData()', () => {
+      testSchema.users.create();
+      testSchema.posts.create();
+      expect(testSchema.users.all().length).toBe(1);
+      expect(testSchema.posts.all().length).toBe(1);
+
+      testSchema.emptyData();
+
+      expect(testSchema.users.all().length).toBe(0);
+      expect(testSchema.posts.all().length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## 📝 Summary
Previously, clearing all collection data required reaching into the underlying DB instance via `schema.db.emptyData()`. This PR adds a `schema.emptyData()` convenience method that wraps it, so data can be cleared directly from the schema.

References, error messages, doc comments, tests, and the README were updated to use the new public API where appropriate. Raw `schema.db` API references (DB API reference, migration guide's direct-database-access section) were intentionally left unchanged.

---

## 🧩 Type of changes
Mark all that apply:

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing behavior to change)
- [ ] 🧹 Refactor (code improvement without changing functionality)
- [x] 🧪 Tests (new or updated tests)
- [x] 🧾 Documentation update

---

## 🧱 Affected modules
Mark all modules impacted by this change:

- [ ] 🧩 associations
- [ ] 🏭 factory
- [ ] 🗄️ db
- [ ] 🪪 id-manager
- [ ] 🧬 model
- [x] 📦 schema
- [ ] ✉️ serializer
- [ ] 🧰 utils

---

## ✅ Checklist
- [x] Build checks pass locally (`pnpm run build:checks`)
- [x] Added or updated tests
- [x] Updated README.md
- [x] Added a Changeset

---

## 🧭 TODO / Nice to do next
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
